### PR TITLE
build: removed aarch64-unknown-linux-gnu target

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,8 +14,6 @@ jobs:
                       archive: zip
                     - target: x86_64-unknown-linux-musl
                       archive: tar.gz tar.xz
-                    - target: aarch64-unknown-linux-gnu
-                      archive: tar.gz tar.xz
                     - target: x86_64-apple-darwin
                       archive: zip
         steps:


### PR DESCRIPTION
Removed aarch64-unknown-linux-gnu build target since github actions don't support arm. 